### PR TITLE
EnsureSuccessStatusCodeHandler instead of API Middleware

### DIFF
--- a/AspNetCore-Effective-Logging/BookClub.Infrastructure/Middleware/ApiExceptionMiddleware.cs
+++ b/AspNetCore-Effective-Logging/BookClub.Infrastructure/Middleware/ApiExceptionMiddleware.cs
@@ -1,67 +1,70 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using System;
 using System.Net;
 using System.Threading.Tasks;
 
 namespace BookClub.Infrastructure.Middleware
 {
-    public class ApiExceptionMiddleware
-    {
-        private readonly RequestDelegate _next;
-        private readonly ILogger<ApiExceptionMiddleware> _logger;
-        private readonly ApiExceptionOptions _options;
+	public class ApiExceptionMiddleware
+	{
+		private readonly RequestDelegate _next;
+		private readonly ILogger<ApiExceptionMiddleware> _logger;
+		private readonly ApiExceptionOptions _options;
 
-        public ApiExceptionMiddleware(ApiExceptionOptions options, RequestDelegate next, 
-            ILogger<ApiExceptionMiddleware> logger)
-        {
-            _next = next;
-            _logger = logger;
-            _options = options;
-        }
+		public ApiExceptionMiddleware( ApiExceptionOptions options, RequestDelegate next,
+			ILogger<ApiExceptionMiddleware> logger )
+		{
+			_next = next;
+			_logger = logger;
+			_options = options;
+		}
 
-        public async Task Invoke(HttpContext context /* other dependencies */)
-        {
-            try
-            {
-                await _next(context);
-            }
-            catch (Exception ex)
-            {
-                await HandleExceptionAsync(context, ex);
-            }
-        }
+		public async Task Invoke( HttpContext context /* other dependencies */)
+		{
+			try
+			{
+				await _next( context );
+			}
+			catch ( Exception ex )
+			{
+				HandleExceptionAsync( context, ex );
+				throw; // Just let exception be thrown so caller can process it
+			}
+		}
 
-        private Task HandleExceptionAsync(HttpContext context, Exception exception)
-        {
-            var error = new ApiError
-            {
-                Id = Guid.NewGuid().ToString(),
-                Status = (short)HttpStatusCode.InternalServerError,
-                Title = "Some kind of error occurred in the API.  Please use the id and contact our " +
-                        "support team if the problem persists."
-            };
-            
-            _options.AddResponseDetails?.Invoke(context, exception, error);            
+		private void HandleExceptionAsync( HttpContext context, Exception exception )
+		{
+			var error = new ApiError
+			{
+				Id = Guid.NewGuid().ToString(),
+				Status = (short)HttpStatusCode.InternalServerError,
+				Title = "Some kind of error occurred in the API.  Please use the id and contact our " +
+						"support team if the problem persists."
+			};
 
-            var innerExMessage = GetInnermostExceptionMessage(exception);
+			_options.AddResponseDetails?.Invoke( context, exception, error );
 
-            var level = _options.DetermineLogLevel?.Invoke(exception) ?? LogLevel.Error;
-            _logger.Log(level, exception, "BADNESS!!! " + innerExMessage  + " -- {ErrorId}.", error.Id);           
+			var innerExMessage = GetInnermostExceptionMessage( exception );
 
+			var level = _options.DetermineLogLevel?.Invoke( exception ) ?? LogLevel.Error;
+			_logger.Log( level, exception, "BADNESS!!! " + innerExMessage + " -- {ErrorId}.", error.Id );
+
+			// No longer returning 'text' to caller.  Will let exception throw.
+			/*
             var result = JsonConvert.SerializeObject(error);
             context.Response.ContentType = "application/json";
             context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
             return context.Response.WriteAsync(result);
-        }
+			*/
+		}
 
-        private string GetInnermostExceptionMessage(Exception exception)
-        {
-            if (exception.InnerException != null)
-                return GetInnermostExceptionMessage(exception.InnerException);
+		private string GetInnermostExceptionMessage( Exception exception )
+		{
+			if ( exception.InnerException != null )
+				return GetInnermostExceptionMessage( exception.InnerException );
 
-            return exception.Message;
-        }
-    }
+			return exception.Message;
+		}
+	}
 }

--- a/AspNetCore-Effective-Logging/BookClub.Infrastructure/Services/EnsureSuccessStatusCodeHandler.cs
+++ b/AspNetCore-Effective-Logging/BookClub.Infrastructure/Services/EnsureSuccessStatusCodeHandler.cs
@@ -1,0 +1,18 @@
+﻿using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BookClub.Infrastructure.Services
+{
+	public class EnsureSuccessStatusCodeHandler : DelegatingHandler
+	{
+		protected override async Task<HttpResponseMessage> SendAsync( HttpRequestMessage request, CancellationToken cancellationToken )
+		{
+			var response = await base.SendAsync( request, cancellationToken );
+
+			response.EnsureSuccessStatusCode();
+
+			return response;
+		}
+	}
+}

--- a/AspNetCore-Effective-Logging/BookClub.UI/Pages/BookList.cshtml.cs
+++ b/AspNetCore-Effective-Logging/BookClub.UI/Pages/BookList.cshtml.cs
@@ -1,33 +1,30 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
+﻿using BookClub.Infrastructure;
+using BookClub.Infrastructure.BaseClasses;
 using BookClub.Logic.Models;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using BookClub.Infrastructure;
-using BookClub.Infrastructure.BaseClasses;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace BookClub.UI.Pages
 {
-    public class BookListModel : BasePageModel
-    {
-        private readonly ILogger _logger;        
-        public List<BookModel> Books;
+	public class BookListModel : BasePageModel
+	{
+		private readonly IHttpClientFactory _httpClientFactory;
+		public List<BookModel> Books;
 
-        public BookListModel(ILogger<BookListModel> logger, IScopeInformation scope) : base(logger, scope)
-        {
-            _logger = logger;
-        }
+		public BookListModel( IHttpClientFactory httpClientFactory, ILogger<BookListModel> logger, IScopeInformation scope ) : base( logger, scope )
+		{
+			_httpClientFactory = httpClientFactory;
+		}
 
-        public async Task OnGetAsync()
-        {            
-            using (var http = new HttpClient(new StandardHttpMessageHandler(HttpContext, _logger)))
-            {
-                var response = await http.GetAsync("https://localhost:44322/api/Book");
-                Books = JsonConvert.DeserializeObject<List<BookModel>>(
-                    await response.Content.ReadAsStringAsync()).OrderByDescending(a=> a.Id).ToList();                
-            }
-        }       
-    }
+		public async Task OnGetAsync()
+		{
+			var response = await _httpClientFactory.CreateClient( "API" ).GetAsync( "https://localhost:44322/api/Book" );
+			Books = JsonConvert.DeserializeObject<List<BookModel>>(
+				await response.Content.ReadAsStringAsync() ).OrderByDescending( a => a.Id ).ToList();
+		}
+	}
 }

--- a/AspNetCore-Effective-Logging/BookClub.UI/Pages/BookListBad.cshtml.cs
+++ b/AspNetCore-Effective-Logging/BookClub.UI/Pages/BookListBad.cshtml.cs
@@ -1,33 +1,30 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
+﻿using BookClub.Infrastructure;
+using BookClub.Infrastructure.BaseClasses;
 using BookClub.Logic.Models;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using BookClub.Infrastructure;
-using BookClub.Infrastructure.BaseClasses;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace BookClub.UI.Pages
 {
-    public class BookListBadModel : BasePageModel
-    {
-        private readonly ILogger _logger;        
-        public List<BookModel> Books;
+	public class BookListBadModel : BasePageModel
+	{
+		private readonly IHttpClientFactory _httpClientFactory;
+		public List<BookModel> Books;
 
-        public BookListBadModel(ILogger<BookListModel> logger, IScopeInformation scope) : base(logger, scope)
-        {
-            _logger = logger;
-        }
+		public BookListBadModel( IHttpClientFactory httpClientFactory, ILogger<BookListModel> logger, IScopeInformation scope ) : base( logger, scope )
+		{
+			_httpClientFactory = httpClientFactory;
+		}
 
-        public async Task OnGetAsync()
-        {            
-            using (var http = new HttpClient(new StandardHttpMessageHandler(HttpContext, _logger)))
-            {
-                var response = await http.GetAsync("https://localhost:44322/api/Book?throwException=true");
-                Books = JsonConvert.DeserializeObject<List<BookModel>>(
-                    await response.Content.ReadAsStringAsync()).OrderByDescending(a=> a.Id).ToList();                
-            }
-        }       
-    }
+		public async Task OnGetAsync()
+		{
+			var response = await _httpClientFactory.CreateClient( "API" ).GetAsync( "https://localhost:44322/api/Book?throwException=true" );
+			Books = JsonConvert.DeserializeObject<List<BookModel>>(
+				await response.Content.ReadAsStringAsync() ).OrderByDescending( a => a.Id ).ToList();
+		}
+	}
 }

--- a/AspNetCore-Effective-Logging/BookClub.UI/Pages/Create.cshtml.cs
+++ b/AspNetCore-Effective-Logging/BookClub.UI/Pages/Create.cshtml.cs
@@ -8,34 +8,35 @@ using System.Threading.Tasks;
 
 namespace BookClub.UI.Pages
 {
-    public class CreateModel : PageModel
-    {
-        private readonly ILogger<CreateModel> _logger;
+	public class CreateModel : PageModel
+	{
+		private readonly IHttpClientFactory _httpClientFactory;
+		private readonly ILogger<CreateModel> _logger;
 
-        public CreateModel(ILogger<CreateModel> logger)
-        {
-            _logger = logger;
-        }
-        [BindProperty]
-        public Book Book { get; set; }
-        
-        public void OnGet()
-        {
-            Book = new Book();
-        }
-        
-        public async Task<IActionResult> OnPost()
-        {
-            if(!ModelState.IsValid)
-            {
-                return Page();
-            }
-            _logger.LogInformation("Submitting new book: {Book}", Book);
-            using (var http = new HttpClient(new StandardHttpMessageHandler(HttpContext, _logger)))
-            {
-                await http.PostAsJsonAsync("https://localhost:44322/apiERROR/Book", Book);
-            }
-            return RedirectToPage("BookList");
-        }
-    }
+		public CreateModel( IHttpClientFactory httpClientFactory, ILogger<CreateModel> logger )
+		{
+			_httpClientFactory = httpClientFactory;
+			_logger = logger;
+		}
+		[BindProperty]
+		public Book Book { get; set; }
+
+		public void OnGet()
+		{
+			Book = new Book();
+		}
+
+		public async Task<IActionResult> OnPost()
+		{
+			if ( !ModelState.IsValid )
+			{
+				return Page();
+			}
+			_logger.LogInformation( "Submitting new book: {Book}", Book );
+
+			await _httpClientFactory.CreateClient( "API" ).PostAsJsonAsync( "https://localhost:44322/apiERROR/Book", Book );
+
+			return RedirectToPage( "BookList" );
+		}
+	}
 }

--- a/AspNetCore-Effective-Logging/BookClub.UI/StandardHttpMessageHandler.cs
+++ b/AspNetCore-Effective-Logging/BookClub.UI/StandardHttpMessageHandler.cs
@@ -1,61 +1,62 @@
-﻿using System;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authentication;
+﻿using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace BookClub.UI
 {
-    public class StandardHttpMessageHandler : DelegatingHandler
-    {
-        private readonly HttpContext _httpContext;
-        private readonly ILogger _logger;
+	[Obsolete( "Using EnsureSuccessStatusCodeHandler class with registered HttpClient to simply throw errors and will use SpanId to locate all log events (UI and API)." )]
+	public class StandardHttpMessageHandler : DelegatingHandler
+	{
+		private readonly HttpContext _httpContext;
+		private readonly ILogger _logger;
 
-        public StandardHttpMessageHandler(HttpContext httpContext, ILogger logger)
-        {
-            _httpContext = httpContext;
-            _logger = logger;            
-            InnerHandler = new SocketsHttpHandler();
-        }
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, 
-            CancellationToken cancellationToken)
-        {
-            var token = await _httpContext.GetTokenAsync("access_token");
+		public StandardHttpMessageHandler( HttpContext httpContext, ILogger logger )
+		{
+			_httpContext = httpContext;
+			_logger = logger;
+			InnerHandler = new SocketsHttpHandler();
+		}
+		protected override async Task<HttpResponseMessage> SendAsync( HttpRequestMessage request,
+			CancellationToken cancellationToken )
+		{
+			var token = await _httpContext.GetTokenAsync( "access_token" );
 
-            request.Headers.Add("Authorization", $"Bearer {token}");
-            var response = await base.SendAsync(request, cancellationToken);
+			request.Headers.Add( "Authorization", $"Bearer {token}" );
+			var response = await base.SendAsync( request, cancellationToken );
 
-            if (!response.IsSuccessStatusCode)
-            {
-                var jsonContent = await response.Content.ReadAsStringAsync();
-                var error = JObject.Parse(jsonContent);
-                string errorId = null, errorTitle = null, errorDetail = null;
-                if (error != null)
-                {
-                    errorId = error["Id"]?.ToString();
-                    errorTitle = error["Title"]?.ToString();
-                    errorDetail = error["Detail"]?.ToString();
-                }
-                var ex = new Exception("API Failure");
+			if ( !response.IsSuccessStatusCode )
+			{
+				var jsonContent = await response.Content.ReadAsStringAsync();
+				var error = JObject.Parse( jsonContent );
+				string errorId = null, errorTitle = null, errorDetail = null;
+				if ( error != null )
+				{
+					errorId = error[ "Id" ]?.ToString();
+					errorTitle = error[ "Title" ]?.ToString();
+					errorDetail = error[ "Detail" ]?.ToString();
+				}
+				var ex = new Exception( "API Failure" );
 
-                ex.Data.Add("API Route", $"GET {request.RequestUri}");
-                ex.Data.Add("API Status", (int)response.StatusCode);
-                ex.Data.Add("API ErrorId", errorId);
-                ex.Data.Add("API Title", errorTitle);
-                ex.Data.Add("API Detail", errorDetail);
+				ex.Data.Add( "API Route", $"GET {request.RequestUri}" );
+				ex.Data.Add( "API Status", (int)response.StatusCode );
+				ex.Data.Add( "API ErrorId", errorId );
+				ex.Data.Add( "API Title", errorTitle );
+				ex.Data.Add( "API Detail", errorDetail );
 
-                //_logger.LogWarning("API Error when calling {APIRoute}: {APIStatus},", $"GET {request.RequestUri}",
-                //    (int)response.StatusCode);
-                _logger.LogWarning("API Error when calling {APIRoute}: {APIStatus}," +
-                    " {ApiErrorId} - {Title} - {Detail}", 
-                    $"GET {request.RequestUri}", (int)response.StatusCode,
-                    errorId, errorTitle, errorDetail);
-                throw ex;
-            }
-            return response;
-        }
-    }
+				//_logger.LogWarning("API Error when calling {APIRoute}: {APIStatus},", $"GET {request.RequestUri}",
+				//    (int)response.StatusCode);
+				_logger.LogWarning( "API Error when calling {APIRoute}: {APIStatus}," +
+					" {ApiErrorId} - {Title} - {Detail}",
+					$"GET {request.RequestUri}", (int)response.StatusCode,
+					errorId, errorTitle, errorDetail );
+				throw ex;
+			}
+			return response;
+		}
+	}
 }

--- a/AspNetCore-Effective-Logging/BookClub.UI/Startup.cs
+++ b/AspNetCore-Effective-Logging/BookClub.UI/Startup.cs
@@ -1,8 +1,5 @@
-using System.Collections.Generic;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Threading.Tasks;
 using BookClub.Infrastructure;
+using BookClub.Infrastructure.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -10,95 +7,107 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Threading.Tasks;
 
 namespace BookClub.UI
 {
-    public class Startup
-    {
-        public Startup(IConfiguration configuration)
-        {
-            Configuration = configuration;
-        }
+	public class Startup
+	{
+		public Startup( IConfiguration configuration )
+		{
+			Configuration = configuration;
+		}
 
-        public IConfiguration Configuration { get; }
+		public IConfiguration Configuration { get; }
 
-        public void ConfigureServices(IServiceCollection services)
-        {
-            services.AddSingleton<IScopeInformation, ScopeInformation>();
+		public void ConfigureServices( IServiceCollection services )
+		{
+			services.AddSingleton<IScopeInformation, ScopeInformation>();
 
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
+			services.Configure<CookiePolicyOptions>( options =>
+			 {
+				 options.CheckConsentNeeded = context => true;
+				 options.MinimumSameSitePolicy = SameSiteMode.None;
+			 } );
 
-            JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
+			JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
 
-            services.AddAuthentication(options =>
-                {
-                    options.DefaultScheme = "Cookies";
-                    options.DefaultChallengeScheme = "oidc";
-                })
-                .AddCookie("Cookies")
-                .AddOpenIdConnect("oidc", options =>
-                {
-                    options.SignInScheme = "Cookies";
-                    options.Authority = "https://demo.identityserver.io";
+			services.AddAuthentication( options =>
+				 {
+					 options.DefaultScheme = "Cookies";
+					 options.DefaultChallengeScheme = "oidc";
+				 } )
+				.AddCookie( "Cookies" )
+				.AddOpenIdConnect( "oidc", options =>
+				 {
+					 options.SignInScheme = "Cookies";
+					 options.Authority = "https://demo.identityserver.io";
 
-                    options.ClientId = "interactive.confidential";
-                    options.ClientSecret = "secret";
-                    options.ResponseType = "code";
-                    options.Scope.Add("email");
-                    options.Scope.Add("api");
-                    options.Scope.Add("offline_access");
+					 options.ClientId = "interactive.confidential";
+					 options.ClientSecret = "secret";
+					 options.ResponseType = "code";
+					 options.Scope.Add( "email" );
+					 options.Scope.Add( "api" );
+					 options.Scope.Add( "offline_access" );
 
-                    options.GetClaimsFromUserInfoEndpoint = true;
-                    options.SaveTokens = true;
-                    options.ClaimActions.MapAllExcept("nbf", "exp", "aud", "nonce", "iat", "c_hash");
-                    options.Events.OnTicketReceived = e =>
-                    {
-                        e.Principal = TransformClaims(e.Principal);
-                        return Task.CompletedTask;
-                    };
-                });
+					 options.GetClaimsFromUserInfoEndpoint = true;
+					 options.SaveTokens = true;
+					 options.ClaimActions.MapAllExcept( "nbf", "exp", "aud", "nonce", "iat", "c_hash" );
+					 options.Events.OnTicketReceived = e =>
+					 {
+						 e.Principal = TransformClaims( e.Principal );
+						 return Task.CompletedTask;
+					 };
+				 } );
 
-            services.AddRazorPages();
-            services.AddControllers(config =>
-            {
-                var policy = new AuthorizationPolicyBuilder()
-                    .RequireAuthenticatedUser()
-                    .Build();
-                config.Filters.Add(new AuthorizeFilter(policy));
-                //config.Filters.Add(typeof(TrackPagePerformanceFilter));
-            });
-        }
+			// Use EnsureSuccessStatusCodeHandler to simply raise an exception if any HttpClient api call fails
+			// when using "API" configured client.  This eliminates the need for the ApiExceptionMiddleware
+			services
+				.AddHttpContextAccessor() // So that IHttpContextAccessor can be DI in StandardHttpMessageHandler
+				.AddTransient<EnsureSuccessStatusCodeHandler>()
+				.AddHttpClient( "API" )
+				.AddHttpMessageHandler<EnsureSuccessStatusCodeHandler>();
 
-        public void Configure(IApplicationBuilder app)
-        {
-            app.UseExceptionHandler("/Error");
-            app.UseHsts();
-            
-            app.UseHttpsRedirection();
+			services.AddRazorPages();
+			services.AddControllers( config =>
+			 {
+				 var policy = new AuthorizationPolicyBuilder()
+					 .RequireAuthenticatedUser()
+					 .Build();
+				 config.Filters.Add( new AuthorizeFilter( policy ) );
+				//config.Filters.Add(typeof(TrackPagePerformanceFilter));
+			} );
+		}
 
-            app.UseAuthentication();
+		public void Configure( IApplicationBuilder app )
+		{
+			app.UseExceptionHandler( "/Error" );
+			app.UseHsts();
 
-            app.UseStaticFiles();
-            app.UseCookiePolicy();
+			app.UseHttpsRedirection();
 
-            app.UseRouting();
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapRazorPages();
-            });
-        }
+			app.UseAuthentication();
 
-        private ClaimsPrincipal TransformClaims(ClaimsPrincipal principal)
-        {
-            var claims = new List<Claim>();
-            claims.AddRange(principal.Claims);  // retain any claims from originally authenticated user
-            
-            var newIdentity = new ClaimsIdentity(claims, principal.Identity.AuthenticationType, "name", "role");
-            return new ClaimsPrincipal(newIdentity);
-        }
-    }
+			app.UseStaticFiles();
+			app.UseCookiePolicy();
+
+			app.UseRouting();
+			app.UseEndpoints( endpoints =>
+			 {
+				 endpoints.MapRazorPages();
+			 } );
+		}
+
+		private ClaimsPrincipal TransformClaims( ClaimsPrincipal principal )
+		{
+			var claims = new List<Claim>();
+			claims.AddRange( principal.Claims );  // retain any claims from originally authenticated user
+
+			var newIdentity = new ClaimsIdentity( claims, principal.Identity.AuthenticationType, "name", "role" );
+			return new ClaimsPrincipal( newIdentity );
+		}
+	}
 }


### PR DESCRIPTION
…ow from API and rethrow in UI.  The SpanId in log events should now match for all events from UI and API.  Fixes #6

`ApiExceptionMiddleware` - lots of changes due to code formatting unfortunately (in all changed files).  All I really changed was commenting out the 'returning of json'

`StandardHttpMessageHandler` - Only added [obsolete] attribute

`Startup` - Only added lines 66-72

Ugh...it must be tabs vs spaces.  Let me know how you'd like to proceed.