### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/AspNetCore-Effective-Logging/BookClub.API/BookClub.API.csproj
+++ b/AspNetCore-Effective-Logging/BookClub.API/BookClub.API.csproj
@@ -5,14 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel" Version="4.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.6" />
-    <PackageReference Include="NLog.Targets.ElasticSearch" Version="7.3.0" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="4.9.2" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
+    <PackageReference Include="IdentityModel" Version="4.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.17" />
+    <PackageReference Include="NLog.Targets.ElasticSearch" Version="7.6.0" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="4.13.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="5.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi@dahlsailrunner, I found an issue in the BookClub.API.csproj:

Packages IdentityModel v4.3.1, Microsoft.AspNetCore.Authentication.JwtBearer v3.1.6, NLog.Targets.ElasticSearch v7.3.0, NLog.Web.AspNetCore v4.9.2, Serilog.AspNetCore v3.2.0, Serilog.Sinks.Seq v4.0.0, Swashbuckle.AspNetCore v5.5.1 and System.Data.SqlClient v4.8.1 transitively introduce 121 dependencies into aspnetcore-effective-logging’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/aspnetcore-effective-logging.html)), while IdentityModel v4.4.0, Microsoft.AspNetCore.Authentication.JwtBearer v3.1.17, NLog.Targets.ElasticSearch v7.6.0, NLog.Web.AspNetCore v4.13.0, Serilog.AspNetCore v3.4.0, Serilog.Sinks.Seq v5.0.1, Swashbuckle.AspNetCore v5.6.2 and System.Data.SqlClient v4.8.2 can only introduce 89 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/aspnetcore-effective-logging_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose